### PR TITLE
fix: use the main prop for the application entry point.

### DIFF
--- a/cute-name-service/bin/www
+++ b/cute-name-service/bin/www
@@ -32,7 +32,7 @@ const http = require('http');
  * Get port from environment and store in Express.
  */
 
-const port = normalizePort(process.env.PORT || '8081');
+const port = normalizePort(process.env.PORT || '8080');
 app.set('port', port);
 
 /**

--- a/cute-name-service/bin/www
+++ b/cute-name-service/bin/www
@@ -25,7 +25,7 @@
  */
 
 const app = require('../app');
-const debug = require('debug')('nodejs-rest-http:server');
+const debug = require('debug')('nodejs-cache-cute-name:server');
 const http = require('http');
 
 /**

--- a/cute-name-service/package.json
+++ b/cute-name-service/package.json
@@ -1,7 +1,6 @@
 {
   "name": "nodejs-cache-cute-name",
   "version": "1.0.0",
-  "main": "false",
   "author": "Red Hat, Inc.",
   "license": "Apache-2.0",
   "scripts": {
@@ -15,8 +14,9 @@
     "prepublish": "license-reporter report",
     "openshift": "nodeshift --strictSSL=false --nodeVersion=8.x",
     "postinstall": "license-reporter report && license-reporter save --xml licenses.xml",
-    "start": "PORT=8080 node ./bin/www"
+    "start": "node ."
   },
+  "main": "./bin/www",
   "xo": {
     "space": 2,
     "rules": {

--- a/greeting-service/bin/www
+++ b/greeting-service/bin/www
@@ -32,7 +32,7 @@ const http = require('http');
  * Get port from environment and store in Express.
  */
 
-const port = normalizePort(process.env.PORT || '3000');
+const port = normalizePort(process.env.PORT || '8080');
 app.set('port', port);
 
 /**

--- a/greeting-service/bin/www
+++ b/greeting-service/bin/www
@@ -25,7 +25,7 @@
  */
 
 const app = require('../app');
-const debug = require('debug')('nodejs-rest-http:server');
+const debug = require('debug')('nodejs-cache-greeting:server');
 const http = require('http');
 
 /**

--- a/greeting-service/package.json
+++ b/greeting-service/package.json
@@ -12,11 +12,12 @@
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "ci": "npm run lint && npm run test",
     "dependencyCheck": "szero . --ci",
-    "start": "PORT=8080 node ./bin/www",
+    "start": "node .",
     "prepublish": "license-reporter report",
     "openshift": "nodeshift --strictSSL=false --nodeVersion=8.x",
     "postinstall": "license-reporter report && license-reporter save --xml licenses.xml"
   },
+  "main": "./bin/www",
   "xo": {
     "space": 2,
     "rules": {


### PR DESCRIPTION
npm start will now look at the main property for the entry point.  Port 8080 is now set as the default port instead of 3000.   This is a fix related to bucharest-gold/centos7-s2i-nodejs#33\#issuecomment-382587104.

fixes #11